### PR TITLE
Import additional dependencies from the user's data-app at runtime

### DIFF
--- a/src/turbine/function-deploy/Dockerfile
+++ b/src/turbine/function-deploy/Dockerfile
@@ -13,4 +13,4 @@ COPY ./function-app/requirements.txt requirements.txt
 RUN pip install --requirement requirements.txt
 COPY ./function-app .
 
-CMD [ "python", "main.py" ]
+CMD [ "python", "function_server.py" ]

--- a/src/turbine/function-deploy/data-app/__init__.py
+++ b/src/turbine/function-deploy/data-app/__init__.py
@@ -1,3 +1,0 @@
-from main import App
-
-__all__ = [App]

--- a/src/turbine/function-deploy/function-app/function_server.py
+++ b/src/turbine/function-deploy/function-app/function_server.py
@@ -31,6 +31,7 @@ class Funtime(service_pb2_grpc.FunctionServicer):
     def _obtain_client_data_app_function(path_to_data_app: str, function_name: str):
         sys.path.append(path_to_data_app)
         import main
+
         return main.__getattribute__(function_name)
 
     def Process(

--- a/src/turbine/function-deploy/function-app/function_server.py
+++ b/src/turbine/function-deploy/function-app/function_server.py
@@ -1,5 +1,4 @@
 import asyncio
-import importlib.util
 import logging
 import os
 import sys
@@ -21,27 +20,31 @@ Process function given to GRPC server
 
 FUNCTION_NAME = sys.argv[1]
 FUNCTION_ADDRESS = os.getenv("MEROXA_FUNCTION_ADDR")
-PATH_TO_DATA_APP = os.path.normpath(os.path.dirname(__file__) + "/../data-app/main.py")
+PATH_TO_DATA_APP = os.path.normpath(os.path.dirname(__file__) + "/../data-app/")
 
 # Coroutines to be invoked when the event loop is shutting down.
 _cleanup_coroutines = []
 
 
 class Funtime(service_pb2_grpc.FunctionServicer):
+    @staticmethod
+    def _obtain_client_data_app_function(path_to_data_app: str, function_name: str):
+        sys.path.append(path_to_data_app)
+        import main
+        return main.__getattribute__(function_name)
+
     def Process(
         self,
         request: service_pb2.ProcessRecordRequest,
         context: grpc.aio.ServicerContext,
     ) -> service_pb2.ProcessRecordResponse:
-        spec = importlib.util.spec_from_file_location("data-app.main", PATH_TO_DATA_APP)
-        data_app = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(data_app)
-
         # map from rpc => something we can work with
         input_records = proto_records_to_turbine_records(request.records)
 
         # Get the data app function
-        data_app_function = data_app.__getattribute__(FUNCTION_NAME)
+        data_app_function = self._obtain_client_data_app_function(
+            path_to_data_app=PATH_TO_DATA_APP, function_name=FUNCTION_NAME
+        )
 
         # Generate output
         output_records = data_app_function(input_records)

--- a/src/turbine/runner/baserunner.py
+++ b/src/turbine/runner/baserunner.py
@@ -31,6 +31,7 @@ class BaseRunner:
         # for the runners
         sys.path.append(self.path_to_data_app)
         from main import App
+
         return App
 
     async def run_app_local(self):

--- a/src/turbine/runner/baserunner.py
+++ b/src/turbine/runner/baserunner.py
@@ -1,4 +1,3 @@
-import importlib.util
 import json
 import os
 import sys
@@ -12,8 +11,6 @@ class BaseRunner:
     local_runtime = None
 
     def __init__(self, path_to_data_app: str):
-        # use setter to get the app_json and set the local value lmao this is silly
-
         self.path_to_data_app = path_to_data_app
         self.info_runtime = InfoRuntime(self.app_config, self.path_to_data_app)
         self.local_runtime = LocalRuntime(self.app_config, self.path_to_data_app)
@@ -30,26 +27,25 @@ class BaseRunner:
 
     @property
     def data_app(self):
-        spec = importlib.util.spec_from_file_location(
-            "main.py", os.path.join(self.path_to_data_app, "main.py")
-        )
-        data_app = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(data_app)
-        return data_app
+        # Append the user's data application to the execution path
+        # for the runners
+        sys.path.append(self.path_to_data_app)
+        from main import App
+        return App
 
     async def run_app_local(self):
-        await self.data_app.__getattribute__("App").run(self.local_runtime)
+        await self.data_app.run(self.local_runtime)
 
     async def list_functions(self):
         try:
-            await self.data_app.__getattribute__("App").run(self.info_runtime)
+            await self.data_app.run(self.info_runtime)
             return self.info_runtime.functions_list()
         except Exception as e:
-            print(f"something broke\n{e}")
+            print(f"something went wrong: {e}")
 
     async def has_functions(self):
         try:
-            await self.data_app.__getattribute__("App").run(self.info_runtime)
+            await self.data_app.run(self.info_runtime)
             return str(self.info_runtime.has_functions()).lower()
         except Exception as e:
-            print(f"something broke\n{e}")
+            print(f"something went wrong: {e}")

--- a/src/turbine/runner/runner.py
+++ b/src/turbine/runner/runner.py
@@ -48,7 +48,7 @@ class Runner(BaseRunner):
         )
 
         try:
-            await self.data_app.__getattribute__("App").run(environment)
+            await self.data_app.run(environment)
             return
         except Exception as e:
             print(f"{e}")

--- a/src/turbine/runtime/platform.py
+++ b/src/turbine/runtime/platform.py
@@ -228,7 +228,7 @@ class PlatformRuntime(Runtime):
             output_stream="",
             name="",
             command=["python"],
-            args=["main.py", fn.__name__],
+            args=["function_server.py", fn.__name__],
             image=self._image_name,
             pipeline=pipeline_id,
             env_vars=self._secrets,

--- a/src/turbine/templates/python/__init__.py
+++ b/src/turbine/templates/python/__init__.py
@@ -1,3 +1,3 @@
 from main import App
 
-__all__ = [App]
+__all__ = ["App"]

--- a/src/turbine/templates/python/requirements.txt
+++ b/src/turbine/templates/python/requirements.txt
@@ -1,4 +1,2 @@
-autopep8==1.6.0
-aiohttp
 meroxa-py
 turbine-py


### PR DESCRIPTION
 # Description
Turbine-py used `importlib.util.spec_from_file_location` to directly import a user's data application. While this worked for applications that were all located in `main.py` for an application, it resulted in broken imports for anything colocated in other modules. This was due to `spec_from_file_location` only importing the very specific file that it is pointed to. 

Instead of importing a singular module, we can instead add the user's data application to the environment variable `PYTHONPATH`. The python executable being run uses the value of `PYTHONPATH` while attempting to resolve dependencies; which the data-app is one of. 

Fixes #54 

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [x] Deployed to staging

# Additional references

*Any additional links (if appropriate)*