### PR TITLE
Prevent publish actions running multiple times

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,6 +3,8 @@ on:
   release:
     branches:
       - main
+    types:
+      - published
 jobs:
   build-and-publish:
     name: Build and publish Turbine-py distributions to PyPI


### PR DESCRIPTION
 # Description

The GitHub `release` action is triggered by [multiple actions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release). We want to limit that _only_ to `release:published` 

fixes #58 

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Will be tested the next time we publish a version
