### PR TITLE
Set `name` field on function create requests

### DIFF
--- a/src/turbine/runtime/platform.py
+++ b/src/turbine/runtime/platform.py
@@ -253,7 +253,7 @@ class PlatformRuntime(Runtime):
         create_func_params = meroxa.CreateFunctionParams(
             input_stream=records.stream,
             output_stream="",
-            name="",
+            name=f"{fn.__name__}",
             command=["python"],
             args=["function_server.py", fn.__name__],
             image=self._image_name,


### PR DESCRIPTION
 # Description

Populate the names of functions at create time. Doing this will allow us to use the actual name of a user's function in notifications. 

Fixes 

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [x] Deployed to staging

# Additional references

*Any additional links (if appropriate)*