### PR TITLE
Allow no empty collection names or second sources

### DIFF
--- a/src/turbine/runtime/intermediate.py
+++ b/src/turbine/runtime/intermediate.py
@@ -30,11 +30,11 @@ class IntermediateResource:
             config = {}
 
         if not collection:
-            raise Exception(f"A collection name is required for all resources")
+            raise Exception("A collection name is required for all resources")
 
         if self.has_source:
             raise Exception(
-                f"Only one call to Records() is allowed per Meroxa Data Application"
+                "Only one call to Records() is allowed per Meroxa Data Application"
             )
 
         self._persist("source", collection, config)
@@ -47,7 +47,7 @@ class IntermediateResource:
             config = {}
 
         if not collection:
-            raise Exception(f"A collection name is required for all resources")
+            raise Exception("A collection name is required for all resources")
 
         self._persist("destination", collection, config)
 

--- a/src/turbine/runtime/intermediate.py
+++ b/src/turbine/runtime/intermediate.py
@@ -16,6 +16,7 @@ class IntermediateResource:
         self.resource_type: str = ""
         self.collection: str = ""
         self.config: dict = {}
+        self.has_source = False
 
     def _persist(
         self, resource_type: str, collection: str, config: dict[str, str] = None
@@ -27,13 +28,27 @@ class IntermediateResource:
     async def records(self, collection: str, config: dict[str, str] = None) -> None:
         if config is None:
             config = {}
+
+        if not collection:
+            raise Exception(f"A collection name is required for all resources")
+
+        if self.has_source:
+            raise Exception(
+                f"Only one call to Records() is allowed per Meroxa Data Application"
+            )
+
         self._persist("source", collection, config)
+        self.has_source = True
 
     async def write(
         self, records, collection: str, config: dict[str, str] = None
     ) -> None:
         if config is None:
             config = {}
+
+        if not collection:
+            raise Exception(f"A collection name is required for all resources")
+
         self._persist("destination", collection, config)
 
     def __repr__(self):

--- a/src/turbine/runtime/intermediate.py
+++ b/src/turbine/runtime/intermediate.py
@@ -30,11 +30,11 @@ class IntermediateResource:
             config = {}
 
         if not collection:
-            raise Exception("A collection name is required for all resources")
+            raise Exception("A collection name is required when calling records()")
 
         if self.has_source:
             raise Exception(
-                "Only one call to Records() is allowed per Meroxa Data Application"
+                "Only one call to records() is allowed per Meroxa Data Application"
             )
 
         self._persist("source", collection, config)
@@ -47,7 +47,7 @@ class IntermediateResource:
             config = {}
 
         if not collection:
-            raise Exception("A collection name is required for all resources")
+            raise Exception("A collection name is required when calling write()")
 
         self._persist("destination", collection, config)
 


### PR DESCRIPTION
 # Description

Prevents the following:
- Adding more than one source to an application
- Adding resources without specifying a collection name

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

