### PR TITLE
Add dependabot config to automatically update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ".github:"
+
+  # Maintain dependencies for Python
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "requirements.txt:"
+
+  - package-ecosystem: "docker"
+    directory: "/src/turbine/function-deploy"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Dockerfile:"


### PR DESCRIPTION
 Dependabot should open PRs as new versions are found weekly.

Related to https://github.com/meroxa/engineering/issues/24