### PR TITLE
[chore] Make `app name` an optional argument in `turbine-py run` command for local execution

### DIFF
--- a/src/turbine/cli.py
+++ b/src/turbine/cli.py
@@ -69,6 +69,7 @@ def build_parser():
     run.add_argument(
         "app_name",
         help="desired name of application",
+        nargs="?",
     )
     run.set_defaults(func=app_run_test)
 


### PR DESCRIPTION
 # Description

`meroxa apps run` does not pass the name of the app to `turbine-py`'s cli. Our options were to remove the field or make it optional should be need to use it later. I chose to make it optional. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

Before
![Screen Shot 2022-09-14 at 2 00 00 PM](https://user-images.githubusercontent.com/1973524/190246625-f4d2f66b-baa1-4a73-aaa8-b0bad8d39154.png)

After 
![Screen Shot 2022-09-14 at 2 36 40 PM](https://user-images.githubusercontent.com/1973524/190246550-bf05ab46-5dbe-49d4-8856-5150d2749a2f.png)
