### PR TITLE
[ktlo] Auto create releases when new tags are pushed to the repo

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,17 @@
+# Uses the following GH Action: https://github.com/marketplace/actions/automatic-releases
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  create_tagged_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+        id: "automatic_releases"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The benefits of using Turbine include:
 
 ## Getting Started
 
-To get started, you'll need to [download the Meroxa CLI](https://github.com/meroxa/cli#installation-guide). Once downloaded and installed, you'll need to back to your terminal and initialize a new project:
+To get started, you'll need to [download the Meroxa CLI](https://github.com/meroxa/cli#installation-guide). Once downloaded and installed, you'll need to go back to your terminal and initialize a new project:
 
 ```bash
 $ meroxa apps init testapp --lang py

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -7,7 +7,5 @@ Publishing a new version requires the following actions be taken in order:
    $ git tag v1.1.0 
    $ git push origin tag v1.1.0
    ```
-   
-3. Once the tag has been pushed, [create a new release](https://github.com/meroxa/turbine-py/releases/new) with a newly pushed tag 
-   - `Generate Release Notes` will create an annotated diff of changes since last release for the notes 
+3. New tags will trigger the [tagged-release](../.github/workflows/tagged-release.yml) workflow, creating a new release based on your new tag
 4. Once the release is published, GitHub Actions will package and publish a new version of turbine-py to [PyPI](https://pypi.org/project/turbine-py/)


### PR DESCRIPTION
 # Description

Set up automatic releases when new valid semvar tags are pushed to the repository. The pre-existing publishing action should take over and make a new PyPI publish when a release is created. 

Uses this action: https://github.com/marketplace/actions/automatic-releases


## Type of change

Please delete options that are not relevant.

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] Manual Tests
- [ ] Deployed to staging

# Additional references

*Any additional links (if appropriate)*