### PR TITLE
Set Meroxa-Account-UUID Header Value on API Request

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp==3.8.3
 grpcio==1.47.0
-meroxa-py==1.1.1
+meroxa-py==1.1.2

--- a/src/turbine/runner/runner.py
+++ b/src/turbine/runner/runner.py
@@ -49,7 +49,9 @@ class Runner(BaseRunner):
         app_config.git_sha = git_sha
         deployment_spec = PlatformRuntime(
             client_options=ClientOptions(
-                auth=os.environ.get("MEROXA_ACCESS_TOKEN"), url=parsed_url
+                auth=os.environ.get("MEROXA_ACCESS_TOKEN"),
+                url=parsed_url,
+                meroxa_account_uuid=os.environ.get("MEROXA_ACCOUNT_UUID"),
             ),
             image_name=image_name,
             git_sha=git_sha,
@@ -75,7 +77,8 @@ class Runner(BaseRunner):
 
         deployment_spec = IntermediateRuntime(
             client_options=ClientOptions(
-                auth=os.environ.get("MEROXA_ACCESS_TOKEN"), url=parsed_url
+                auth=os.environ.get("MEROXA_ACCESS_TOKEN"),
+                url=parsed_url,
             ),
             image_name=image_name,
             git_sha=git_sha,

--- a/src/turbine/runner/runner.py
+++ b/src/turbine/runner/runner.py
@@ -79,6 +79,7 @@ class Runner(BaseRunner):
             client_options=ClientOptions(
                 auth=os.environ.get("MEROXA_ACCESS_TOKEN"),
                 url=parsed_url,
+                meroxa_account_uuid=os.environ.get("MEROXA_ACCOUNT_UUID"),
             ),
             image_name=image_name,
             git_sha=git_sha,

--- a/src/turbine/runtime/info.py
+++ b/src/turbine/runtime/info.py
@@ -44,10 +44,10 @@ class InfoRuntime(Runtime):
         return f"turbine-response: {bool(len(list(self.registeredFunctions)))}"
 
     def resources_list(self) -> str:
-
-        return json.dumps(
+        resp = json.dumps(
             list(resource.__dict__ for resource in self.registeredResources)
         )
+        return f"turbine-response: {resp}"
 
     async def resources(self, name: str):
         resource = InfoResource(name)

--- a/src/turbine/runtime/intermediate.py
+++ b/src/turbine/runtime/intermediate.py
@@ -2,9 +2,8 @@ import json
 import os
 import typing as t
 
-import meroxa
-
 from .types import AppConfig
+from .types import ClientOptions
 from .types import RecordList
 from .types import Records
 from .types import Runtime
@@ -86,7 +85,7 @@ class IntermediateRuntime(Runtime):
 
     def __init__(
         self,
-        client_options: meroxa.ClientOptions,
+        client_options: ClientOptions,
         image_name: str,
         git_sha: str,
         version: str,

--- a/src/turbine/runtime/platform.py
+++ b/src/turbine/runtime/platform.py
@@ -9,6 +9,7 @@ from meroxa.pipelines import PipelineIdentifiers
 from meroxa.types import ResourceType
 
 from .types import AppConfig
+from .types import ClientOptions
 from .types import RecordList
 from .types import Records
 from .types import Resource
@@ -26,7 +27,7 @@ class PlatformResource(Resource):
     _pipeline_name = ""
 
     def __init__(
-        self, resource, client_options: meroxa.ClientOptions, app_config: AppConfig
+        self, resource, client_options: ClientOptions, app_config: AppConfig
     ) -> None:
         self.resource = resource
         self.app_config = app_config
@@ -42,7 +43,9 @@ class PlatformResource(Resource):
         )
 
         async with Meroxa(
-            auth=self.client_opts.auth, api_route=self.client_opts.url
+            auth=self.client_opts.auth,
+            api_route=self.client_opts.url,
+            meroxa_account_uuid=self.client_opts.meroxa_account_uuid,
         ) as m:
             resp = await m.applications.create(app_input)
 
@@ -61,7 +64,9 @@ class PlatformResource(Resource):
             environment=self.app_config.environment,
         )
         async with Meroxa(
-            auth=self.client_opts.auth, api_route=self.client_opts.url
+            auth=self.client_opts.auth,
+            api_route=self.client_opts.url,
+            meroxa_account_uuid=self.client_opts.meroxa_account_uuid,
         ) as m:
             resp = await m.pipelines.create(pipeline_input)
 
@@ -85,7 +90,9 @@ class PlatformResource(Resource):
                 config["conduit"] = "true"
 
             async with Meroxa(
-                auth=self.client_opts.auth, api_route=self.client_opts.url
+                auth=self.client_opts.auth,
+                api_route=self.client_opts.url,
+                meroxa_account_uuid=self.client_opts.meroxa_account_uuid,
             ) as m:
                 resp = await m.pipelines.get(self._pipeline_name)
 
@@ -119,7 +126,9 @@ class PlatformResource(Resource):
             )
 
             async with Meroxa(
-                auth=self.client_opts.auth, api_route=self.client_opts.url
+                auth=self.client_opts.auth,
+                api_route=self.client_opts.url,
+                meroxa_account_uuid=self.client_opts.meroxa_account_uuid,
             ) as m:
                 connector: meroxa.ConnectorsResponse
                 # Error Handling: Duplicate connector
@@ -196,7 +205,9 @@ class PlatformResource(Resource):
             )
 
             async with Meroxa(
-                auth=self.client_opts.auth, api_route=self.client_opts.url
+                auth=self.client_opts.auth,
+                api_route=self.client_opts.url,
+                meroxa_account_uuid=self.client_opts.meroxa_account_uuid,
             ) as m:
                 resp = await m.connectors.create(connector_input)
             if resp[0] is not None:
@@ -225,7 +236,7 @@ class PlatformRuntime(Runtime):
 
     def __init__(
         self,
-        client_options: meroxa.ClientOptions,
+        client_options: ClientOptions,
         image_name: str,
         git_sha: str,
         config: AppConfig,
@@ -240,7 +251,9 @@ class PlatformRuntime(Runtime):
 
         try:
             async with Meroxa(
-                auth=self._client_opts.auth, api_route=self._client_opts.url
+                auth=self._client_opts.auth,
+                api_route=self._client_opts.url,
+                meroxa_account_uuid=self._client_opts.meroxa_account_uuid,
             ) as m:
                 resp = await m.resources.get(resource_name)
 
@@ -287,7 +300,9 @@ class PlatformRuntime(Runtime):
         print(f"Deploying Process: {getattr(fn, '__name__', 'Unknown')}")
 
         async with Meroxa(
-            auth=self._client_opts.auth, api_route=self._client_opts.url
+            auth=self._client_opts.auth,
+            api_route=self._client_opts.url,
+            meroxa_account_uuid=self._client_opts.meroxa_account_uuid,
         ) as m:
             resp = await m.functions.create(create_func_params)
         try:

--- a/src/turbine/runtime/types.py
+++ b/src/turbine/runtime/types.py
@@ -100,6 +100,7 @@ class AppConfig:
 
 
 class ClientOptions:
-    def __init__(self, auth: str, url: str) -> None:
+    def __init__(self, auth: str, url: str, meroxa_account_uuid: str) -> None:
         self.auth = auth
         self.url = url
+        self.meroxa_account_uuid = meroxa_account_uuid

--- a/tests/runtime/test_intermediate.py
+++ b/tests/runtime/test_intermediate.py
@@ -14,7 +14,9 @@ from turbine.runtime.types import Records
 @pytest.fixture(scope="function")
 def intermediate_runtime():
     return IntermediateRuntime(
-        client_options=ClientOptions(auth="TOKEN", url="URL"),
+        client_options=ClientOptions(
+            auth="TOKEN", url="URL", meroxa_account_uuid="ACCT"
+        ),
         image_name="IMAGE",
         git_sha="SHASHASHA",
         version="1.3.0",


### PR DESCRIPTION
 # Description

Meroxa-py client now requires meroxa_account_uuid which will then be set as a header value for Meroxa-Acconut-UUID. This change reads the value of the `MEROXA_ACCOUNT_UUID` envvar and passes it along to meroxa-py as needed. 

Fixes https://github.com/meroxa/turbine-project/issues/277

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [ ] Manual Tests
- [ ] Deployed to staging

