### PR TITLE
docs(README): add note on how to install req. turbine-py dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ The benefits of using Turbine include:
 To get started, you'll need to install the `turbine-py` dependency via `pip`:
 
 ```bash
-# For users of python version < 3
-pip install turbine-py
-
 # For users of python 3+
 pip3 install turbine-py
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ The benefits of using Turbine include:
 
 ## Getting Started
 
-To get started, you'll need to [download the Meroxa CLI](https://github.com/meroxa/cli#installation-guide). Once downloaded and installed, you'll need to back to your terminal and initialize a new project:
+To get started, you'll need to install the `turbine-py` dependency via `pip`:
+
+```bash
+# For users of python version < 3
+pip install turbine-py
+
+# For users of python 3+
+pip3 install turbine-py
+```
+
+Next, you'll need to [download the Meroxa CLI](https://github.com/meroxa/cli#installation-guide). Once downloaded and installed, initialize a new project using the following CLI command:
 
 ```bash
 $ meroxa apps init testapp --lang py

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The benefits of using Turbine include:
 To get started, you'll need to install the `turbine-py` dependency via `pip`:
 
 ```bash
-# For users of python 3+
 pip3 install turbine-py
 ```
 


### PR DESCRIPTION
 # Description

Follow-up to https://github.com/meroxa/product/issues/586

While testing the creation of turbine-py apps in the context of the collaboration feature, I noticed that we don't mention [the required install of the turbine-py dependency](https://docs.meroxa.com/turbine/develop/python#requirements) in our project README yet as opposed to [the Meroxa docs](https://docs.meroxa.com/turbine/develop/python#requirements):

![Screen Shot 2022-10-20 at 4 02 39 PM](https://user-images.githubusercontent.com/8811742/196970383-cf80e31c-dc30-4abf-bf64-784489a90e49.png)

This adds the `turbine-py` installation command to the README's `Getting Started` section.

For more context, see also [the related discussion on Slack](https://meroxa.slack.com/archives/C02L14X6TA9/p1666270373003089).

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

# Additional references

![accountpytest](https://user-images.githubusercontent.com/8811742/196970646-75fb9028-07b7-4e9a-8702-2b5406103397.gif)

