### PR TITLE
Fix functions created with IR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.vscode

--- a/src/turbine/function-deploy/Dockerfile
+++ b/src/turbine/function-deploy/Dockerfile
@@ -20,4 +20,4 @@ COPY ./function-app .
 #Set user permissions to nonroot
 USER nobody
 
-CMD [ "python", "function_server.py" ]
+ENTRYPOINT [ "python", "function_server.py" ]

--- a/src/turbine/runtime/intermediate.py
+++ b/src/turbine/runtime/intermediate.py
@@ -63,7 +63,7 @@ class IntermediateFunction:
     image: str
 
     def __init__(self, name: str, commit_hash: str, image: str):
-        self.name = f"{name}-{commit_hash[:8]}"
+        self.name = name
         self.image = image
 
     def serialize(self):

--- a/tests/runtime/test_intermediate.py
+++ b/tests/runtime/test_intermediate.py
@@ -105,7 +105,7 @@ class TestIntermediateFunction:
     def test_init(self):
         func = IntermediateFunction("funcname", "1234567890", "coolimage")
 
-        assert func.name == "funcname-12345678"
+        assert func.name == "funcname"
         assert func.image == "coolimage"
 
     def test_repr(self):
@@ -113,7 +113,7 @@ class TestIntermediateFunction:
 
         assert (
             func.serialize().items()
-            <= {"name": "funcname-12345678", "image": "coolimage"}.items()
+            <= {"name": "funcname", "image": "coolimage"}.items()
         )
 
 
@@ -156,7 +156,7 @@ class TestIntermediateRuntime:
 
         rf = intermediate_runtime._registered_functions[0]
         assert len(intermediate_runtime._registered_functions) == 1
-        assert rf.name == "<lambda>-SHASHASH"
+        assert rf.name == "<lambda>"
 
     def test_register_secrets(self, intermediate_runtime, monkeypatch):
         monkeypatch.setenv("TEST", "testvalue")


### PR DESCRIPTION
 # Description

When trying to create a function using an IR spec, the function gets stuck in an error state. The function pod reports:
```
  Warning  Failed     2m55s (x3 over 3m10s)  kubelet            Error: failed to start container "function": Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "anonymize-83e7c39d": executable file not found in $PATH: unknown
```

This is because to run the function container, the following command needs to be executed: `python function_server.py anonymize`

Before IR, the `CMD` outlined in the Dockerfile is overwritten with the full command https://github.com/meroxa/turbine-py/blob/439ec0797974bdd22a40d16bc08fdc6f957ad055/src/turbine/runtime/platform.py#L290-L291

In IR, only the function name is provided as an argument, which overwrites the full command, only leaving the function name.  (instead of `python function_server.py anonymize`, we see `anonymize-83e7c39d`)

Also, the function name had a git sha attached to it. This also breaks the container from being executed.


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [X] Manual Tests with spec
- - [X] Manual Tests without spec
- [ ] Deployed to staging

# Additional references

*Any additional links (if appropriate)*
