### PR TITLE
Specify `python:3.9-slim` base image in build Dockerfile

### DIFF
--- a/src/turbine/function-deploy/Dockerfile
+++ b/src/turbine/function-deploy/Dockerfile
@@ -1,5 +1,5 @@
 # Build Data App
-FROM python:slim-buster as DATA_APP_BUILDER
+FROM python:3.9-slim as DATA_APP_BUILDER
 
 RUN pip install --upgrade pip
 


### PR DESCRIPTION
 # Description

Fixes: https://github.com/meroxa/turbine-project/issues/279

Python image builds are failing with the following error
```
[2022-10-25T13:09:50Z]  > [ 7/12] RUN pip install --requirement requirements.txt:
[2022-10-25T13:09:50Z] #11 13.70       creating build/temp.linux-x86_64-cpython-311
[2022-10-25T13:09:50Z] #11 13.70       creating build/temp.linux-x86_64-cpython-311/yarl
[2022-10-25T13:09:50Z] #11 13.70       gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.11 -c yarl/_quoting_c.c -o build/temp.linux-x86_64-cpython-311/yarl/_quoting_c.o
[2022-10-25T13:09:50Z] #11 13.70       error: command 'gcc' failed: No such file or directory
[2022-10-25T13:09:50Z] #11 13.70       [end of output]
[2022-10-25T13:09:50Z] #11 13.70   
[2022-10-25T13:09:50Z] #11 13.70   note: This error originates from a subprocess, and is likely not a problem with pip.
[2022-10-25T13:09:50Z] #11 13.70   ERROR: Failed building wheel for yarl
[2022-10-25T13:09:50Z] #11 13.70 Failed to build frozenlist multidict yarl
[2022-10-25T13:09:50Z] #11 13.70 ERROR: Could not build wheels for frozenlist, multidict, yarl, which is required to install pyproject.toml-based projects
[2022-10-25T13:09:50Z] ------
[2022-10-25T13:09:50Z] Dockerfile:11
[2022-10-25T13:09:50Z] --------------------
[2022-10-25T13:09:50Z]    9 |     WORKDIR /app/data-app
[2022-10-25T13:09:50Z]   10 |     COPY ./data-app/requirements.txt requirements.txt
[2022-10-25T13:09:50Z]   11 | >>> RUN pip install --requirement requirements.txt
[2022-10-25T13:09:50Z]   12 |     COPY ./data-app .
[2022-10-25T13:09:50Z]   13 |     
[2022-10-25T13:09:50Z] --------------------
[2022-10-25T13:09:50Z] error: failed to solve: process "/bin/sh -c pip install --requirement requirements.txt" did not complete successfully: exit code: 1
```


The current Dockerfile specifies the following for a base image

```Dockerfile
FROM python:slim-buster as DATA_APP_BUILDER
```

This pulls the most recent `slim-buster` version of the base python image. In 3.10.x/3.11.x the `slim-buster` version purges build packages to make the image smaller. One of the purged packages is `gcc`. 

Changing our Dockerfile to contain

```Dockerfile
FROM python:3.9-slim as DATA_APP_BUILDER
```

Gives us two benefits:
1. we're pinned to a specific version of python
2. gcc is not purged 

We may have to look into this again when 3.9 is EOL'd in the future. (2025) 


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

# Additional references

*Any additional links (if appropriate)*
