### PR TITLE
fix: set build command for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
         with:
           token: ${{ secrets.MEROXA_MACHINE }}
           fetch-depth: 0
+      - name: Install pypa/build
+          run: >-
+            python -m
+            pip install
+            build
+            --user
       - name: Python Semantic Release
         uses: relekang/python-semantic-release@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,7 @@ jobs:
           token: ${{ secrets.MEROXA_MACHINE }}
           fetch-depth: 0
       - name: Install pypa/build
-        run: >-
-          python -m
-          pip install
-          build
-          --user
+        run: python -m pip install build --user
       - name: Python Semantic Release
         uses: relekang/python-semantic-release@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
           token: ${{ secrets.MEROXA_MACHINE }}
           fetch-depth: 0
       - name: Install pypa/build
-          run: >-
-            python -m
-            pip install
-            build
-            --user
+        run: >-
+          python -m
+          pip install
+          build
+          --user
       - name: Python Semantic Release
         uses: relekang/python-semantic-release@master
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools"]
+requires = [
+  "setuptools >= 40.9.0",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.9
 
 install_requires =
     aiohttp>=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,4 @@ changelog_file = CHANGELOG.md
 upload_to_repository = true
 # create a GH release note and upload artifacts
 upload_to_release = true
+build_command = python -m build


### PR DESCRIPTION
 # Description

The default build command for python semantic release is outdated and incompatible with the structure of turbine-py. This caused a GitHub Action failure while trying to publish a new version of turbine-py https://github.com/meroxa/turbine-py/actions/runs/3438576186/jobs/5735183397

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

# Additional references

*Any additional links (if appropriate)*
