### PR TITLE
patch: Switch to commit tagging now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ where = src
 [semantic_release]
 version_variable = src/turbine/__init__.py:__version__
 # derive version from tags
-version_source = tag
+version_source = commit
 branch = main
 changelog_file = CHANGELOG.md
 # let semantic release manage PyPI uploads

--- a/src/turbine/__init__.py
+++ b/src/turbine/__init__.py
@@ -1,4 +1,4 @@
 """
 Semantic release checks and updates version variable
 """
-__version__ = "1.5.3"
+__version__ = "1.6.0"


### PR DESCRIPTION
 # Description

Previously set up semantic-release to read tags rather than versions due to an inconsistent commit messages in the history for this repo. We now have semantic release set up and do not need to worry about that.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] Manual Tests
- [ ] Deployed to staging

# Additional references

*Any additional links (if appropriate)*
