### PR TITLE
Add app path to version

### DIFF
--- a/src/turbine/cli.py
+++ b/src/turbine/cli.py
@@ -47,7 +47,8 @@ def app_clean_up(path_to_temp, **kwargs):
     Runner.clean_temp_directory(path_to_temp)
 
 
-def app_return_version(**kwargs):
+def app_return_version(path_to_data_app, **kwargs):
+    r = Runner(path_to_data_app)
     dist = distribution("turbine-py")
     print(f"turbine-response: {dist.version}")
 
@@ -124,6 +125,7 @@ def build_parser():
 
     # return the current version of turbine-py
     lib_version = subparser.add_parser("version")
+    lib_version.add_argument("path_to_data_app", help="path to app ")
     lib_version.set_defaults(func=app_return_version)
 
     return parser

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,7 +101,7 @@ class TestCli:
 
     def test_return_version(self, capsys):
         parser = build_parser()
-        args = parser.parse_args(["version"])
+        args = parser.parse_args(["version", PATH_TO_TEMP])
         args.func(**vars(args))
 
         output = capsys.readouterr()


### PR DESCRIPTION
 # Description

Acceptance tests are currently failing when trying to deploy py apps with the error:
```
        Error: unable to determine the version of turbine-py used by the Meroxa Application at /apps/turbine_py/tmp/app/py-acceptance-app-7e4a219a-7d07-4361-9615-9369b5c085be
```
https://github.com/meroxa/platform-api/actions/runs/3517135522/jobs/5895166625#step:4:3051

Before
```
turbine-py version /Users/dianadoherty/go/src/meroxa/test-py
usage: turbine-py [-h] {generate,run,clideploy,functions,hasFunctions,listResources,clibuild,cliclean,version} ...
turbine-py: error: unrecognized arguments: /Users/dianadoherty/go/src/meroxa/test-py
```

After 
```
meroxa turbine-py version /Users/dianadoherty/go/src/meroxa/test-py
turbine-response: 1.6.2
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] Manual Tests
- [ ] Deployed to staging

# Additional references

*Any additional links (if appropriate)*
