### PR TITLE
fix: update template reqs; require newest version of meroxa-py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ python_requires = >=3.9
 install_requires =
     aiohttp>=3.8
     grpcio>=1.44.0
-    meroxa-py
+    meroxa-py>=1.1.2
 
 [options.entry_points]
 console_scripts =

--- a/src/turbine/templates/python/requirements.txt
+++ b/src/turbine/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-turbine-py==1.5.2
+turbine-py==1.6.4


### PR DESCRIPTION
 # Description

This change updates the turbine-py version in the template requirements file. Additionally, this change now requires the _newest_ version of meroxa-py when doing a `pip update` rather than just _a version_ . 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

