### PR TITLE
feat: If the collection is not required, pass the whole fixtures to the fun…

### DIFF
--- a/src/turbine/runtime/local.py
+++ b/src/turbine/runtime/local.py
@@ -19,11 +19,7 @@ async def read_fixtures(path: str, collection: str):
             fc = json.load(content)
 
             if collection == "":
-                fixtures.append(
-                    Record(
-                        key="", value=fc, timestamp=time.time()
-                    )
-                )
+                fixtures.append(Record(key="", value=fc, timestamp=time.time()))
 
             if collection in fc:
                 for rec in fc[collection]:

--- a/src/turbine/runtime/local.py
+++ b/src/turbine/runtime/local.py
@@ -18,6 +18,13 @@ async def read_fixtures(path: str, collection: str):
         with open(path, "r") as content:
             fc = json.load(content)
 
+            if collection == "":
+                fixtures.append(
+                    Record(
+                        key="", value=fc, timestamp=time.time()
+                    )
+                )
+
             if collection in fc:
                 for rec in fc[collection]:
                     fixtures.append(


### PR DESCRIPTION
…ction when locally testing

 # Description

It was hard to debug a function with a source resource that doesn't require a collection locally because the function was never truly exercised. The passed in RecordsList was always empty. 

Fixes https://github.com/meroxa/turbine-py/issues/216

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif/terminal output -->|<!-- Replace this with a screenshot/gif/terminal output -->|

# Additional references

*Any additional links (if appropriate)*
