### PR TITLE
fix: make sure path is converted for windows

### DIFF
--- a/src/turbine/runner/baserunner.py
+++ b/src/turbine/runner/baserunner.py
@@ -23,7 +23,9 @@ class BaseRunner:
     def app_config(self):
         config = {}
         try:
-            with open(os.path.abspath(f"{self.path_to_data_app}") + "/app.json") as fd:
+            with open(
+                os.path.abspath(os.path.join(self.path_to_data_app, " app.json"))
+            ) as fd:
                 config = AppConfig(**json.load(fd))
                 if self.app_name != "":
                     config.name = self.app_name


### PR DESCRIPTION
 # Description
Ensures that the path to the app.json is correct on windows machines

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
